### PR TITLE
Recover immutable-tag PyPI publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,10 @@ on:
         description: Successful Release candidate wheel matrix run ID for this exact commit
         required: true
         type: string
+      release_sha:
+        description: Exact commit referenced by the immutable release tag
+        required: true
+        type: string
       expected_version:
         description: Exact adam-assist PEP 440 release-candidate version
         required: true
@@ -17,6 +21,15 @@ on:
         required: true
         default: 0.5.6rc5
         type: string
+      expected_rust_crate_sha256:
+        description: Exact published adam_assist crate checksum
+        required: true
+        type: string
+      recovery_from_main:
+        description: Permit a default-branch dispatch that still checks out the immutable release tag
+        required: true
+        default: false
+        type: boolean
       confirmation:
         description: Type "publish adam-assist <version> from <sha> to pypi"
         required: true
@@ -33,20 +46,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: v${{ inputs.expected_version }}
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
       - name: Install wheel filename parser
         run: |
           python -m pip install --only-binary=:all: packaging
-      - name: Verify exact RC tag and irreversible-action confirmation
+      - name: Verify immutable release tag and irreversible-action confirmation
         env:
           CONFIRMATION: ${{ inputs.confirmation }}
           EXPECTED_VERSION: ${{ inputs.expected_version }}
-          EXPECTED_SHA: ${{ github.sha }}
+          EXPECTED_SHA: ${{ inputs.release_sha }}
+          RECOVERY_FROM_MAIN: ${{ inputs.recovery_from_main }}
         run: |
           set -euo pipefail
-          test "$GITHUB_REF" = "refs/tags/v$EXPECTED_VERSION"
+          case "$GITHUB_REF" in
+            "refs/tags/v$EXPECTED_VERSION") test "$RECOVERY_FROM_MAIN" = "false" ;;
+            refs/heads/main) test "$RECOVERY_FROM_MAIN" = "true" ;;
+            *) echo "publication must run from the release tag or an explicit main recovery" >&2; exit 1 ;;
+          esac
+          test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
           test "$CONFIRMATION" = "publish adam-assist $EXPECTED_VERSION from $EXPECTED_SHA to pypi"
       - name: Verify source prerelease and exact adam-core dependency
         env:
@@ -90,17 +111,41 @@ jobs:
               raise SystemExit("temporary vendored core crates must be absent")
           PY
       - name: Require the matching public Rust crate
+        env:
+          EXPECTED_CHECKSUM: ${{ inputs.expected_rust_crate_sha256 }}
         run: |
-          set -euo pipefail
-          crate_json="$(curl --fail --silent --show-error \
-            https://crates.io/api/v1/crates/adam_assist/0.4.0-rc.6)"
-          test "$(jq -r .version.num <<<"$crate_json")" = "0.4.0-rc.6"
-          test "$(jq -r .version.yanked <<<"$crate_json")" = "false"
+          python - <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          request = urllib.request.Request(
+              "https://index.crates.io/ad/am/adam_assist",
+              headers={
+                  "User-Agent": (
+                      "adam-assist-release-check/0.4.0rc6 "
+                      "(+https://github.com/B612-Asteroid-Institute/adam-assist)"
+                  )
+              },
+          )
+          with urllib.request.urlopen(request) as response:
+              entries = [json.loads(line) for line in response if line.strip()]
+          matches = [entry for entry in entries if entry["vers"] == "0.4.0-rc.6"]
+          if len(matches) != 1:
+              raise SystemExit(f"expected one public Rust crate entry, found {len(matches)}")
+          entry = matches[0]
+          if entry["yanked"]:
+              raise SystemExit("adam_assist 0.4.0-rc.6 is yanked")
+          if entry["cksum"] != os.environ["EXPECTED_CHECKSUM"]:
+              raise SystemExit(f"unexpected adam_assist checksum: {entry['cksum']}")
+          if entry.get("rust_version") != "1.87":
+              raise SystemExit(f"unexpected adam_assist MSRV: {entry.get('rust_version')}")
+          PY
       - name: Verify acceptance provenance
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_ID: ${{ inputs.acceptance_run_id }}
-          EXPECTED_SHA: ${{ github.sha }}
+          EXPECTED_SHA: ${{ inputs.release_sha }}
         run: |
           set -euo pipefail
           RUN_JSON="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}")"
@@ -185,15 +230,15 @@ jobs:
                   if packaged_tests:
                       raise SystemExit(f"{wheel.name}: packaged tests {packaged_tests[:1]}")
               requirements = [Requirement(value) for value in metadata.get_all("Requires-Dist", [])]
-              by_name = {canonicalize_name(requirement.name): requirement for requirement in requirements}
-              observed_requirements = {
-                  name: str(by_name[name].specifier)
-                  for name in expected_requirements
-                  if name in by_name
+              unconditional_requirements = {
+                  canonicalize_name(requirement.name): str(requirement.specifier)
+                  for requirement in requirements
+                  if requirement.marker is None
               }
-              if observed_requirements != expected_requirements:
+              if unconditional_requirements != expected_requirements:
                   raise SystemExit(
-                      f"{wheel.name}: bad release dependencies {observed_requirements}"
+                      f"{wheel.name}: bad release dependencies "
+                      f"{unconditional_requirements}"
                   )
               interpreters = {tag.interpreter for tag in tags}
               abis = {tag.abi for tag in tags}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,11 @@ on:
         required: true
         default: false
         type: boolean
+      dry_run:
+        description: Verify and assemble exact artifacts without entering the PyPI environment
+        required: true
+        default: false
+        type: boolean
       confirmation:
         description: Type "publish adam-assist <version> from <sha> to pypi"
         required: true
@@ -60,15 +65,30 @@ jobs:
           EXPECTED_VERSION: ${{ inputs.expected_version }}
           EXPECTED_SHA: ${{ inputs.release_sha }}
           RECOVERY_FROM_MAIN: ${{ inputs.recovery_from_main }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
           case "$GITHUB_REF" in
-            "refs/tags/v$EXPECTED_VERSION") test "$RECOVERY_FROM_MAIN" = "false" ;;
-            refs/heads/main) test "$RECOVERY_FROM_MAIN" = "true" ;;
-            *) echo "publication must run from the release tag or an explicit main recovery" >&2; exit 1 ;;
+            "refs/tags/v$EXPECTED_VERSION")
+              test "$RECOVERY_FROM_MAIN" = "false"
+              test "$DRY_RUN" = "false"
+              ;;
+            refs/heads/main)
+              test "$RECOVERY_FROM_MAIN" = "true"
+              test "$DRY_RUN" = "false"
+              ;;
+            refs/heads/release/pypi-0.4.0rc6-recovery)
+              test "$RECOVERY_FROM_MAIN" = "false"
+              test "$DRY_RUN" = "true"
+              ;;
+            *) echo "publication must run from the release tag or an explicit recovery" >&2; exit 1 ;;
           esac
           test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
-          test "$CONFIRMATION" = "publish adam-assist $EXPECTED_VERSION from $EXPECTED_SHA to pypi"
+          if [ "$DRY_RUN" = "true" ]; then
+            test "$CONFIRMATION" = "verify adam-assist $EXPECTED_VERSION from $EXPECTED_SHA for pypi"
+          else
+            test "$CONFIRMATION" = "publish adam-assist $EXPECTED_VERSION from $EXPECTED_SHA to pypi"
+          fi
       - name: Verify source prerelease and exact adam-core dependency
         env:
           EXPECTED_VERSION: ${{ inputs.expected_version }}
@@ -272,6 +292,7 @@ jobs:
           if-no-files-found: error
 
   publish-pypi:
+    if: inputs.dry_run == false
     needs: collect-tested-artifacts
     runs-on: ubuntu-latest
     environment:

--- a/tests/test_ci_contract.py
+++ b/tests/test_ci_contract.py
@@ -76,7 +76,10 @@ def test_rust_crate_workflows_package_once_and_publish_tested_bytes() -> None:
     assert 'entry.get("rust_version") != "1.87"' in python_publisher
     assert "release_sha:" in python_publisher
     assert "recovery_from_main:" in python_publisher
+    assert "dry_run:" in python_publisher
     assert "refs/heads/main" in python_publisher
+    assert "refs/heads/release/pypi-0.4.0rc6-recovery" in python_publisher
+    assert "if: inputs.dry_run == false" in python_publisher
     assert "ref: v${{ inputs.expected_version }}" in python_publisher
     assert "EXPECTED_SHA: ${{ inputs.release_sha }}" in python_publisher
     assert "unconditional_requirements != expected_requirements" in python_publisher

--- a/tests/test_ci_contract.py
+++ b/tests/test_ci_contract.py
@@ -69,8 +69,17 @@ def test_rust_crate_workflows_package_once_and_publish_tested_bytes() -> None:
 
     python_publisher = (ROOT / ".github" / "workflows" / "publish.yml").read_text()
     assert "Require the matching public Rust crate" in python_publisher
-    assert "api/v1/crates/adam_assist/0.4.0-rc.6" in python_publisher
-    assert 'test "$(jq -r .version.yanked' in python_publisher
+    assert "https://index.crates.io/ad/am/adam_assist" in python_publisher
+    assert "api/v1/crates/adam_assist" not in python_publisher
+    assert 'entry["yanked"]' in python_publisher
+    assert 'entry["cksum"]' in python_publisher
+    assert 'entry.get("rust_version") != "1.87"' in python_publisher
+    assert "release_sha:" in python_publisher
+    assert "recovery_from_main:" in python_publisher
+    assert "refs/heads/main" in python_publisher
+    assert "ref: v${{ inputs.expected_version }}" in python_publisher
+    assert "EXPECTED_SHA: ${{ inputs.release_sha }}" in python_publisher
+    assert "unconditional_requirements != expected_requirements" in python_publisher
     assert "testpypi" not in python_publisher.lower()
     assert "to pypi" in python_publisher
 


### PR DESCRIPTION
## Summary
- make Python publication check the crates.io sparse index with an identifying client instead of the API endpoint that rejects generic curl
- support an explicit default-branch recovery that still checks out and verifies immutable tag `v0.4.0rc6` at `9c32abab2b077cc27c0ccc5a20e37b9a90e6a543`
- require the exact public Rust crate checksum and exact three unconditional Python runtime dependencies

## Recovery invariants
- acceptance run remains `32865575837`
- no wheel rebuild or release-tag movement
- publication confirmation remains bound to the exact release SHA
- `main` recovery must be explicitly selected; ordinary releases remain tag-only

## Validation
- 18 focused publication/CI/dependency tests passed
- lint, formatting, strict mypy, YAML parsing, and embedded-Python compilation passed
- exact 12-wheel staged publication set passed the updated verifier
- immutable-tag/default-branch recovery guard passed
